### PR TITLE
Add async mode to match gzip-size

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,22 @@ var stream = require('stream');
  * @param {!Buffer|string} str
  * @param {!Object=} opt_params
  */
-module.exports.sync = function(str, opt_params) {
+function brotliSize(str, opt_params) {
+  if (typeof str == 'string') {
+    str = new Buffer(str, 'utf8');
+  }
+  return iltorb.compress(str, opt_params).then(function(result) {
+    return result.length;
+  });
+}
+
+module.exports = brotliSize;
+
+/**
+ * @param {!Buffer|string} str
+ * @param {!Object=} opt_params
+ */
+brotliSize.sync = function(str, opt_params) {
   if (typeof str == 'string') {
     str = new Buffer(str, 'utf8');
   }
@@ -18,7 +33,7 @@ module.exports.sync = function(str, opt_params) {
 /**
  * @param {!Object=} opt_params
  */
-module.exports.stream = function(opt_params) {
+brotliSize.stream = function(opt_params) {
   opt_params = opt_params || {};
   var input = new stream.PassThrough();
   var output = new stream.PassThrough();

--- a/test.js
+++ b/test.js
@@ -1,28 +1,35 @@
 import fs from 'fs';
 import test from 'ava';
-import module from './';
+import brotliSize from './';
 
 const file = fs.readFileSync('test.js', 'utf8');
 
+test('async - get the brotli size', async (t) => {
+  t.plan(2);
+  const size = await brotliSize(file);
+  t.true(typeof size === 'number');
+  t.true(size < file.length);
+});
+
 test('sync - get the brotli size', (t) => {
   t.plan(1);
-  t.true(module.sync(file) < file.length);
+  t.true(brotliSize.sync(file) < file.length);
 });
 
 test.cb('stream', t => {
   fs.createReadStream('test.js')
-    .pipe(module.stream())
+    .pipe(brotliSize.stream())
     .on('end', function() {
-      t.is(this.brotliSize, module.sync(file));
+      t.is(this.brotliSize, brotliSize.sync(file));
       t.end();
     });
 });
 
 test.cb('brotli-size event', t => {
   fs.createReadStream('test.js')
-    .pipe(module.stream())
+    .pipe(brotliSize.stream())
     .on('brotli-size', size => {
-      t.is(size, module.sync(file));
+      t.is(size, brotliSize.sync(file));
       t.end();
     });
 });


### PR DESCRIPTION
Hiya! Thanks for the great module.  This PR adds support for a promise-based `brotliSize(str)` default export, which matches how gzip-size works. I've also added a test.